### PR TITLE
Don't restrict pushitem "filename" to basenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- Push item "filename" is no longer restricted to basenames only.
 
 ## [1.0.0] - 2019-07-24
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pushcollector",
-    version="1.0.0",
+    version="1.1.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/pushcollector/_impl/schema/pushitem.yaml
+++ b/src/pushcollector/_impl/schema/pushitem.yaml
@@ -11,7 +11,8 @@ type: object
 properties:
   # A filename for this push item.
   #
-  # Only a filename (basename) should be provided, with no leading path.
+  # The filename should always include the basename component of a file's path.
+  # It may optionally include leading path components.
   #
   # A non-empty filename must always be provided, even for push items which do
   # not represent a file. In such cases, an identifier for the push item which
@@ -21,7 +22,6 @@ properties:
   # despite that manifests are not guaranteed to be stored as files.
   filename:
     type: string
-    pattern: "^[^/]+$"
 
   # The state of this push item.
   state:

--- a/tests/local/test_local.py
+++ b/tests/local/test_local.py
@@ -18,7 +18,7 @@ def test_local_saves_to_artifacts(caplog, tmpdir, monkeypatch):
     collector.update_push_items(
         [
             {"filename": "file1", "state": "PUSHED"},
-            {"filename": "file2", "state": "INVALIDFILE"},
+            {"filename": "somedir/file2", "state": "INVALIDFILE"},
         ]
     ).result()
     collector.update_push_items([{"filename": "file3", "state": "MISSING"}]).result()
@@ -42,7 +42,7 @@ def test_local_saves_to_artifacts(caplog, tmpdir, monkeypatch):
         == textwrap.dedent(
             """
             {"filename": "file1", "state": "PUSHED"}
-            {"filename": "file2", "state": "INVALIDFILE"}
+            {"filename": "somedir/file2", "state": "INVALIDFILE"}
             {"filename": "file3", "state": "MISSING"}
             """
         ).lstrip()


### PR DESCRIPTION
In the push item schema, the filename field was restricted to holding
only the basename of files with no leading path components.

This turns out to be a mistake in the design because the tools
expected to use this library don't work that way, and do have a few
cases of storing filenames with leading paths.  Operator metadata
bundles are one example, such as:
hco-bundle-registry-container-v2.0.0-42/operator_manifests.zip

So, let's loosen up the schema and allow any string to be provided
as a filename.

Fixes #7