### PR TITLE
Pushcollector accepts PushItem objects along with raw dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+before_install:
+  # for rpm-py-installer
+  - sudo apt-get install -y rpm
 install: pip install tox
 matrix:
   include:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,4 +135,5 @@ intersphinx_mapping = {
     # "requests": ("https://2.python-requests.org/en/master/", None),
     "more-executors": ("https://rohanpm.github.io/more-executors/", None),
     # "attrs": ("https://www.attrs.org/en/stable/", None),
+    "pushsource": ("https://release-engineering.github.io/pushsource/", None),
 }

--- a/src/pushcollector/_impl/collector.py
+++ b/src/pushcollector/_impl/collector.py
@@ -20,8 +20,9 @@ class Collector(object):
         """Record a state change on one or more push items.
 
         Arguments:
-            items (List[dict])
-                    A list of push item dicts.
+            items (List[dict], List[:class:`~pushsource.PushItem`])
+                    A list of push item dicts or list of :class:`~pushsource.PushItem`
+                    objects
 
                     Each dict must have, at minimum, "filename" and "state"
                     keys. For complete information on the format of push item

--- a/src/pushcollector/_impl/collector.py
+++ b/src/pushcollector/_impl/collector.py
@@ -22,7 +22,7 @@ class Collector(object):
         Arguments:
             items (List[dict], List[:class:`~pushsource.PushItem`])
                     A list of push item dicts or list of :class:`~pushsource.PushItem`
-                    objects
+                    objects.
 
                     Each dict must have, at minimum, "filename" and "state"
                     keys. For complete information on the format of push item

--- a/src/pushcollector/_impl/proxy.py
+++ b/src/pushcollector/_impl/proxy.py
@@ -4,6 +4,7 @@ import six
 from more_executors.futures import f_return, f_map
 import yaml
 import jsonschema
+import inspect
 
 
 def empty_future(value):
@@ -50,11 +51,48 @@ class CollectorProxy(object):
     def __init__(self, delegate):
         self._delegate = delegate
 
-    def update_push_items(self, items):
-        for item in items:
-            jsonschema.validate(item, schema=self._ITEM_SCHEMA)
+    def _translate_pushitem(self, pushitem):
+        def _get_checksum():
+            if pushitem.md5sum and pushitem.sha256sum:
+                return {"md5": pushitem.md5sum, "sha256": pushitem.sha256sum}
+            else:
+                return None
 
-        return empty_future(self._delegate.update_push_items(items))
+        pushitem = {
+            "filename": pushitem.name,
+            "state": pushitem.state,
+            "src": pushitem.src,
+            "dest": str(pushitem.dest) if pushitem.dest else None,
+            "checksums": _get_checksum(),
+            "origin": pushitem.origin,
+            "build": pushitem.build,
+            "signing_key": pushitem.signing_key,
+        }
+
+        return pushitem
+
+    def _is_pushitem_obj(self, pushitem):
+        # check if the object is an instance of PushItem or
+        # its subclass using inspect instead of instanceof
+        # as pushsource depends on pushcollector module which
+        # leads to cyclic dependency
+        for item_cls in inspect.getmro(type(pushitem)):
+            if item_cls.__name__ == "PushItem" and item_cls.__module__.startswith(
+                "pushsource"
+            ):
+                return True
+
+        return False
+
+    def update_push_items(self, items):
+        pushitems = []
+        for item in items:
+            if self._is_pushitem_obj(item):
+                item = self._translate_pushitem(item)
+            jsonschema.validate(item, schema=self._ITEM_SCHEMA)
+            pushitems.append(item)
+
+        return empty_future(self._delegate.update_push_items(pushitems))
 
     def attach_file(self, filename, content):
         content = maybe_encode(content)

--- a/src/pushcollector/_impl/proxy.py
+++ b/src/pushcollector/_impl/proxy.py
@@ -66,17 +66,20 @@ class CollectorProxy(object):
             "state": pushitem.state,
             "src": pushitem.src,
             "dest": None,
-            "checksums": checksums if checksums else None,
+            "checksums": checksums or None,
             "origin": pushitem.origin,
             "build": pushitem.build,
             "signing_key": pushitem.signing_key,
         }
 
-        if pushitem.dest:
-            for dest in pushitem.dest:
-                push_item_copy = push_item.copy()
-                push_item_copy["dest"] = dest
-                pushitems.append(push_item_copy)
+        # a pushitem dict for each destination from the
+        # list of destinations in PushItem object is
+        # returned else a single pushitem with dest None
+        # as expected in the pushitem schema
+        for dest in pushitem.dest or []:
+            push_item_copy = push_item.copy()
+            push_item_copy["dest"] = dest
+            pushitems.append(push_item_copy)
 
         return pushitems or [push_item]
 

--- a/src/pushcollector/_impl/proxy.py
+++ b/src/pushcollector/_impl/proxy.py
@@ -4,7 +4,6 @@ import six
 from more_executors.futures import f_return, f_map
 import yaml
 import jsonschema
-import inspect
 
 
 def empty_future(value):
@@ -75,9 +74,9 @@ class CollectorProxy(object):
 
         if pushitem.dest:
             for dest in pushitem.dest:
-                p = push_item.copy()
-                p["dest"] = dest
-                pushitems.append(p)
+                push_item_copy = push_item.copy()
+                push_item_copy["dest"] = dest
+                pushitems.append(push_item_copy)
 
         return pushitems or [push_item]
 
@@ -85,7 +84,8 @@ class CollectorProxy(object):
         pushitems = []
         for item in items:
             item_dicts = self._translate_pushitem(item)
-            [jsonschema.validate(item, schema=self._ITEM_SCHEMA) for item in item_dicts]
+            for item_dict in item_dicts:
+                jsonschema.validate(item_dict, schema=self._ITEM_SCHEMA)
             pushitems.extend(item_dicts)
 
         return empty_future(self._delegate.update_push_items(pushitems))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 pytest
+mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 pytest
 mock
+pushsource
+rpm-py-installer

--- a/tests/proxy/test_argument_handling.py
+++ b/tests/proxy/test_argument_handling.py
@@ -61,15 +61,15 @@ def test_pushitem_obj_attributes():
 
     update_push_item_args = mock.update_push_items.call_args[0][0]
     assert len(update_push_item_args) == 2
-    for i in range(len(update_push_item_args)-1):
+    for i in range(len(update_push_item_args) - 1):
         push_args = update_push_item_args[i]
         assert push_args["filename"] == pushitem.name
         assert push_args["state"] == pushitem.state
         assert push_args["src"] == pushitem.src
         assert push_args["dest"] == pushitem.dest[i]
         assert push_args["checksums"] == {
-                "md5": pushitem.md5sum,
-                "sha256": pushitem.sha256sum,
+            "md5": pushitem.md5sum,
+            "sha256": pushitem.sha256sum,
         }
         assert push_args["origin"] == pushitem.origin
         assert push_args["build"] == pushitem.build

--- a/tests/proxy/test_argument_handling.py
+++ b/tests/proxy/test_argument_handling.py
@@ -22,7 +22,7 @@ def test_pushitem_obj_push():
 
     collector = Collector.get("dummy")
 
-    pushitem = PushItem("test_pushitem")
+    pushitem = PushItem(name="test_pushitem")
     ret_val = collector.update_push_items([pushitem])
 
     assert ret_val.result() is None
@@ -46,7 +46,7 @@ def test_pushitem_obj_attributes():
     collector = Collector.get("mock")
 
     pushitem = PushItem(
-        "test_push",
+        name="test_push",
         origin="some_origin",
         src="source",
         dest=["dest1", "dest2"],

--- a/tests/proxy/test_argument_handling.py
+++ b/tests/proxy/test_argument_handling.py
@@ -1,5 +1,8 @@
 import jsonschema
 import pytest
+from mock import Mock
+
+from pushsource import PushItem
 
 from pushcollector import Collector
 
@@ -12,3 +15,58 @@ def test_bad_push_items():
 
     with pytest.raises(jsonschema.ValidationError):
         coll.update_push_items([{"foo": "bar"}])
+
+
+def test_pushitem_obj_push():
+    """PushItem object passed to the update_push_items works fine."""
+
+    collector = Collector.get("dummy")
+
+    pushitem = PushItem("test_pushitem")
+    ret_val = collector.update_push_items([pushitem])
+
+    assert ret_val.result() is None
+
+
+def test_bad_obj_push():
+    """Any object apart from PushItem type raises a validation error."""
+
+    collector = Collector.get("dummy")
+
+    pushitem = object()
+    with pytest.raises(jsonschema.ValidationError):
+        collector.update_push_items([pushitem])
+
+
+def test_pushitem_obj_attributes():
+    """PushItem object attributes are translated and available as expected in
+    pushitem dict passed to update_push_items"""
+
+    Collector.register_backend("mock", Mock)
+    collector = Collector.get("mock")
+
+    pushitem = PushItem(
+        "test_push",
+        origin="some_origin",
+        src="source",
+        dest=["dest1", "dest2"],
+        md5sum="bb1b0d528129f47798006e73307ba7a7",
+        sha256sum="4fd23ae44f3366f12f769f82398e96dce72adab8e45dea4d721ddf43fdce31e2",
+        build="test_build",
+        signing_key="FD431D51",
+    )
+    collector.update_push_items([pushitem])
+
+    update_push_item_args = collector._delegate.update_push_items.call_args[0][0]
+    push_args = update_push_item_args[0]
+    assert push_args["filename"] == pushitem.name
+    assert push_args["state"] == pushitem.state
+    assert push_args["src"] == pushitem.src
+    assert push_args["dest"] == str(pushitem.dest)
+    assert push_args["checksums"] == {
+        "md5": pushitem.md5sum,
+        "sha256": pushitem.sha256sum,
+    }
+    assert push_args["origin"] == pushitem.origin
+    assert push_args["build"] == pushitem.build
+    assert push_args["signing_key"] == pushitem.signing_key

--- a/tests/proxy/test_argument_handling.py
+++ b/tests/proxy/test_argument_handling.py
@@ -74,3 +74,28 @@ def test_pushitem_obj_attributes():
         assert push_args["origin"] == pushitem.origin
         assert push_args["build"] == pushitem.build
         assert push_args["signing_key"] == pushitem.signing_key
+
+
+def test_minimal_pushitem_obj():
+    """PushItem object with minimal attributes is translated to
+    pushitem dict with destination and checksums as None along
+    with other attributes as in the object"""
+
+    mock = Mock()
+    Collector.register_backend("mock", lambda: mock)
+    collector = Collector.get("mock")
+
+    pushitem = PushItem(name="test_push")
+    collector.update_push_items([pushitem])
+
+    update_push_item_args = mock.update_push_items.call_args[0][0]
+    assert len(update_push_item_args) == 1
+    push_args = update_push_item_args[0]
+    assert push_args["filename"] == pushitem.name
+    assert push_args["state"] == pushitem.state
+    assert push_args["src"] == pushitem.src
+    assert push_args["dest"] is None
+    assert push_args["checksums"] is None
+    assert push_args["origin"] == pushitem.origin
+    assert push_args["build"] == pushitem.build
+    assert push_args["signing_key"] == pushitem.signing_key


### PR DESCRIPTION
Pushcollector library only accepted push items as raw dicts.
This patch modifies update_push_items to accept PushItem objects
from Pushsource library along with the raw dicts.