### PR TITLE
Adding bandit to pipeline [RHELDST-12098]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -80,3 +80,17 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e docs
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: sudo apt-get install -y rpm
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e bandit

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,static,pidiff,docs
+envlist = py27,py36,static,pidiff,docs,bandit
 
 [testenv]
 deps=-rtest-requirements.txt
@@ -37,17 +37,6 @@ usedevelop=true
 commands=
 	pytest --cov-report=html --cov-report=xml --cov=src {posargs}
 
-[testenv:cov-travis]
-passenv = TRAVIS TRAVIS_*
-deps=
-	-rtest-requirements.txt
-	pytest-cov
-	coveralls
-usedevelop=true
-commands=
-	pytest --cov=src {posargs}
-	coveralls
-
 [testenv:docs]
 deps=
 	sphinx
@@ -58,3 +47,8 @@ commands=
 
 [pytest]
 testpaths = tests
+
+
+[testenv:bandit]
+deps = bandit
+commands = bandit -r . -ll --exclude './.tox,./misc/ci'


### PR DESCRIPTION
As part of improving security of our tools, we're adding bandit to CI/CD pipelines.

This change adds bandit to the git-actions pipeline for this repo. Running bandit locally showed no security issues.