### PR TITLE
Pin bandit version

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM
-        run: sudo apt-get install -y rpm
+        run: sudo apt-get install -y rpm libkrb5-dev
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pytest
 mock
 pushsource
 rpm-py-installer
+bandit==1.7.5

--- a/tox.ini
+++ b/tox.ini
@@ -43,5 +43,5 @@ testpaths = tests
 
 
 [testenv:bandit]
-deps = bandit
+deps = -rtest-requirements.txt
 commands = bandit -r . -ll --exclude './.tox,./misc/ci'


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to tox.ini.