### PR TITLE
Onboard test coverage to Codecov [RHELDST-40407]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -33,6 +33,8 @@ jobs:
         run: tox -e pidiff
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - name: Install RPM
@@ -45,6 +47,14 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref =='refs/heads/master')
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: coverage.xml
+          fail_ci_if_error: false
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Python library for collecting information from push tasks, used by
 [release-engineering](https://github.com/release-engineering) publishing tools.
 
 [![Build Status](https://travis-ci.org/release-engineering/pushcollector.svg?branch=master)](https://travis-ci.org/release-engineering/pushcollector)
-[![Coverage Status](https://coveralls.io/repos/github/release-engineering/pushcollector/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/pushcollector?branch=master)
+[![Coverage Status](https://app.codecov.io/gh/release-engineering/pushcollector)](https://app.codecov.io/gh/release-engineering/pushcollector)
 
 - [Source](https://github.com/release-engineering/pushcollector)
 - [Documentation](https://release-engineering.github.io/pushcollector/)


### PR DESCRIPTION
Adds the codecov action to the coverage workflow in tox-test.yml
Updates Coverage Status in README.md to point to codecov